### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v1
       
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         registry: docker.pkg.github.com
         name: ${{ github.repository }}/vertx-configmap-example


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore